### PR TITLE
[Composer] Move phpunit dependency to require-dev block

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,10 @@
 
     "require": {
         "ext-json": "*",
-        "psr/simple-cache": "*",
+        "psr/simple-cache": "*"
+    },
+    
+    "require-dev": {
         "phpunit/phpunit": "^4.8"
     },
 


### PR DESCRIPTION
- This prevents pulling many dependencies in a non-development environment